### PR TITLE
Hera module files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ forecast:
   mpas:
     namelist:
       update_values:
-        forecast:
+        physics:
           config_microp_scheme = 'mp_thompson'
 ```
 

--- a/build.sh
+++ b/build.sh
@@ -310,12 +310,12 @@ printf "\nATMOS_ONLY: ${ATMOS_ONLY}\n"
 
 if [ ${ATMOS_ONLY} = false ]; then
   make clean CORE=atmosphere
-  make ifort CORE=init_atmosphere ${MPAS_MAKE_OPTIONS}
+  make intel-mpi CORE=init_atmosphere ${MPAS_MAKE_OPTIONS}
   cp -v init_atmosphere_model ${EXEC_DIR}
   make clean CORE=init_atmosphere
 fi
 
-make ifort CORE=atmosphere ${MPAS_MAKE_OPTIONS}
+make intel-mpi CORE=atmosphere ${MPAS_MAKE_OPTIONS}
 cp -v atmosphere_model ${EXEC_DIR}
 
 if [ "${CLEAN}" = true ]; then

--- a/build.sh
+++ b/build.sh
@@ -309,7 +309,7 @@ cd ${MPAS_DIR}/src/MPAS-Model
 printf "\nATMOS_ONLY: ${ATMOS_ONLY}\n"
 
 if [ ${ATMOS_ONLY} = false ]; then
-  make clean CORE=atmosphere_model
+  make clean CORE=atmosphere
   make ifort CORE=init_atmosphere ${MPAS_MAKE_OPTIONS}
   cp -v init_atmosphere_model ${EXEC_DIR}
   make clean CORE=init_atmosphere

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -1,0 +1,25 @@
+help([[
+This module loads libraries for building the MPAS App on
+the NOAA RDHPC machine Hera using Intel-2023.2.0
+]])
+
+whatis([===[Loads libraries needed for building the MPAS App on Hera ]===])
+
+load("cmake/3.28.1")
+load("gnu")
+load("intel/2023.2.0")
+load("impi/2023.2.0")
+
+--prepend_path("PATH", "/apps/oneapi/mpi/2021.10.0/bin")
+--prepend_path("LD_LIBRARY_PATH", "/apps/oneapi/mpi/2021.10.0/lib")
+
+load("pnetcdf/1.12.3")
+load("szip")
+load("hdf5parallel/1.10.5")
+load("netcdf-hdf5parallel/4.7.0")
+
+setenv("PNETCDF", "/apps/pnetcdf/1.12.3/intel_2023.2.0-impi")
+setenv("CMAKE_C_COMPILER", "mpiicc")
+setenv("CMAKE_CXX_COMPILER", "mpiicpc")
+setenv("CMAKE_Fortran_COMPILER", "mpiifort")
+

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -12,7 +12,7 @@ load("gnu")
 load("intel/2022.1.2")
 load("impi/2022.1.2")
 
-load("pnetcdf/1.11.2")
+load("pnetcdf/1.7.0")
 load("szip")
 load("hdf5parallel/1.10.6")
 load("netcdf-hdf5parallel/4.7.0")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -15,7 +15,7 @@ load("impi/2022.1.2")
 load("pnetcdf/1.7.0")
 load("szip")
 load("hdf5parallel/1.10.6")
-load("netcdf-hdf5parallel/4.7.0")
+load("netcdf-hdf5parallel/4.7.4")
 
 setenv("PNETCDF", "/apps/pnetcdf/1.11.2/intel/2022.1.2")
 setenv("CMAKE_C_COMPILER", "mpiicc")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -5,7 +5,7 @@ the NOAA RDHPC machine Hera using Intel-2022.1.2
 
 whatis([===[Loads libraries needed for building the MPAS App on Hera ]===])
 
-load("cmake/3.28.1")
+load("cmake/3.23.1")
 load("gnu")
 load("intel/2022.1.2")
 load("impi/2022.1.2")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -4,7 +4,9 @@ the NOAA RDHPC machine Hera using Intel-2022.1.2
 ]])
 
 whatis([===[Loads libraries needed for building the MPAS App on Hera ]===])
+prepend_path("MODULEPATH", "/scratch1/NCEPDEV/nems/role.epic/spack-stack/spack-stack-1.5.1/envs/unified-env-rocky8/install/modulefiles/Core")
 
+load("stack-intel/2021.5.0")
 load("cmake/3.23.1")
 load("gnu")
 load("intel/2022.1.2")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -17,7 +17,6 @@ load("szip")
 load("hdf5parallel/1.10.6")
 load("netcdf-hdf5parallel/4.7.4")
 
-setenv("PNETCDF", "/apps/pnetcdf/1.11.2/intel/2022.1.2")
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")
 setenv("CMAKE_Fortran_COMPILER", "mpiifort")

--- a/modulefiles/build_hera_intel.lua
+++ b/modulefiles/build_hera_intel.lua
@@ -1,24 +1,21 @@
 help([[
 This module loads libraries for building the MPAS App on
-the NOAA RDHPC machine Hera using Intel-2023.2.0
+the NOAA RDHPC machine Hera using Intel-2022.1.2
 ]])
 
 whatis([===[Loads libraries needed for building the MPAS App on Hera ]===])
 
 load("cmake/3.28.1")
 load("gnu")
-load("intel/2023.2.0")
-load("impi/2023.2.0")
+load("intel/2022.1.2")
+load("impi/2022.1.2")
 
---prepend_path("PATH", "/apps/oneapi/mpi/2021.10.0/bin")
---prepend_path("LD_LIBRARY_PATH", "/apps/oneapi/mpi/2021.10.0/lib")
-
-load("pnetcdf/1.12.3")
+load("pnetcdf/1.11.2")
 load("szip")
-load("hdf5parallel/1.10.5")
+load("hdf5parallel/1.10.6")
 load("netcdf-hdf5parallel/4.7.0")
 
-setenv("PNETCDF", "/apps/pnetcdf/1.12.3/intel_2023.2.0-impi")
+setenv("PNETCDF", "/apps/pnetcdf/1.11.2/intel/2022.1.2")
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")
 setenv("CMAKE_Fortran_COMPILER", "mpiifort")

--- a/modulefiles/wflow_hera.lua
+++ b/modulefiles/wflow_hera.lua
@@ -1,0 +1,16 @@
+help([[
+This module loads the python environment for running the MPAS App on 
+the NOAA RDHPC machine Hera
+]]) 
+ 
+whatis([===[Loads libraries needed for running the MPAS App on Hera ]===]) 
+
+load("rocoto")
+load("conda")
+
+if mode() == "load" then
+    LmodMsgRaw([===[Please do the following to activate conda:
+	>conda activate mpas_app
+]===])
+end
+


### PR DESCRIPTION
Adding the module files to compile app on Hera, will update documentation when the rest of the Hera platform support is complete and the app can fully run on Hera.

intel-mpi run on hera:
/scratch2/BMC/wrfruc/jderrico/mpas/mpas-dev/hera/conus/2023091500
intel-mpi run on jet:
/lfs4/BMC/wrfruc/jderrico/mpas/mpas_dev/demo/mpas_app/expt_dir/2023091500