### PR TITLE
Update model hash and jet build 

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ forecast:
   mpas:
     namelist:
       update_values:
-        forecast:
+        physics:
           config_microp_scheme = 'mp_thompson'
 ```
 

--- a/modulefiles/build_jet_intel.lua
+++ b/modulefiles/build_jet_intel.lua
@@ -8,17 +8,15 @@ prepend_path("MODULEPATH","/mnt/lfs4/HFIP/hfv3gfs/role.epic/spack-stack/spack-st
 prepend_path("MODULEPATH", "/lfs4/HFIP/hfv3gfs/spack-stack/modulefiles")
 
 load("stack-intel/2021.5.0")
-load("cmake/3.23.1")
+load("cmake/3.28.1")
 load("gnu")
-load("intel/2022.1.2")
-load("impi/2022.1.2")
+load("intel/2023.2.0")
+load("impi/2023.2.0")
 
-load("pnetcdf")
+load("pnetcdf/1.12.3")
 load("szip")
-load("hdf5parallel/1.10.6")
-load("netcdf-hdf5parallel/4.7.4")
-
-setenv("PIO", "/lfs4/BMC/wrfruc/jderrico/mpas/PIOV2")
+load("hdf5parallel/1.10.5")
+load("netcdf-hdf5parallel/4.7.0")
 
 setenv("CMAKE_C_COMPILER","mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicc")

--- a/ush/default_config.yaml
+++ b/ush/default_config.yaml
@@ -59,7 +59,7 @@ create_ics:
         - module load build_{{ user.platform }}_intel
       executable: "{{ user.mpas_app }}/exec/init_atmosphere_model"
       mpiargs:
-        - "--ntasks=4"
+        - "--ntasks={{ create_ics.mpas_init['execution']['batchargs']['cores']}}"
       mpicmd: srun
     files_to_copy: &mpas_init_files_to_copy
       "{{ user.mesh_label }}.static.nc": "{{ data.mesh_files }}/{{ user.mesh_label }}.static.nc"


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

updates the MPAS-Model hash to June 6, 2024 version of gsl/develop

modifies the jet intel module file to include more recent versions of intel, impi, and pnetcdf.  Removes PIO library as it is no longer needed with more recent versions of MPAS

**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [x] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.