### PR TITLE
update default mesh locations

### DIFF
--- a/parm/machines/hera.yaml
+++ b/parm/machines/hera.yaml
@@ -1,4 +1,4 @@
 data:
-  mesh_files: /scratch2/BMC/wrfruc/jderrico/mpas/mpas-dev/test-mesh
+  mesh_files: /scratch2/BMC/gsd-fv3-dev/mpas_dev/15km-conus/
 platform:
   scheduler: slurm

--- a/parm/machines/jet.yaml
+++ b/parm/machines/jet.yaml
@@ -1,5 +1,5 @@
 data:
-  mesh_files: /lfs4/BMC/wrfruc/jderrico/mpas/mpas_dev/meshes/15km-conus/
+  mesh_files: /lfs5/BMC/gsd-fv3-dev/mpas_dev/meshes/15km-conus/
 platform:
   scheduler: slurm
 forecast:


### PR DESCRIPTION
<!--

INSTRUCTIONS

- Please do not commit temporary, backup, or binary files.
- Please remove commented-out code.
- Please ensure code, config files, etc., contain no hardcoded paths.
- Please format code snippets in PR description/comments with ```code block``` or `inline code`.
- Please consider adding your own review comments to guide other reviewers.

-->

**Synopsis**

This PR changes the default mesh locations for both jet and hera:
jet: /lfs5/BMC/gsd-fv3-dev/mpas_dev/meshes/15km-conus/
hera: /scratch2/BMC/gsd-fv3-dev/mpas_dev/15km-conus/

The mesh directories on both platforms include an `info.txt` that provides the date and model hash used to create the mesh static files and cutouts.

Ran successfully on both platforms with new defaults:
jet: /lfs5/BMC/wrfruc/jderrico/mpas/dev/data_test/2023091500
hera: /scratch2/BMC/wrfruc/jderrico/mpas/dev/data_test/2023091500
 
**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [x] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [ ] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [ ] This is a breaking change (changes existing functionality)
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.
