### PR TITLE
[Bugfix-main] Ungrib forecast length fix

### DIFF
--- a/parm/wflow/cold_start.yaml
+++ b/parm/wflow/cold_start.yaml
@@ -52,7 +52,7 @@ workflow:
         ICS_or_LBCS: LBCS
         TIME_OFFSET_HRS: 0
         LBC_INTVL_HRS: 6
-        FCST_LEN: 12
+        FCST_LEN: !int "{{ forecast.mpas.length }}" 
         MPAS_APP: '&MPAS_APP;'
     task_ungrib:
       command: 'source &MPAS_APP;/load_wflow_modules.sh &PLATFORM; ; python &MPAS_APP;/scripts/ungrib.py'

--- a/ush/default_config.yaml
+++ b/ush/default_config.yaml
@@ -36,7 +36,7 @@ prepare_grib:
       executable: ungrib
     gribfiles:
       interval_hours: 6
-      max_leadtime: 24
+      max_leadtime: !int "{{ forecast.mpas.length }}"
       offset: 0
       path: "{{ get_lbcs_data.rundir }}/gfs.t{cycle_hour:02d}z.pgrb2.0p25.f{forecast_hour:03d}"
     rundir: '{{ user.experiment_dir }}/{{cycle.strftime("%Y%m%d%H")}}/ungrib'

--- a/ush/default_config.yaml
+++ b/ush/default_config.yaml
@@ -36,7 +36,7 @@ prepare_grib:
       executable: ungrib
     gribfiles:
       interval_hours: 6
-      max_leadtime: 12
+      max_leadtime: 24
       offset: 0
       path: "{{ get_lbcs_data.rundir }}/gfs.t{cycle_hour:02d}z.pgrb2.0p25.f{forecast_hour:03d}"
     rundir: '{{ user.experiment_dir }}/{{cycle.strftime("%Y%m%d%H")}}/ungrib'
@@ -48,7 +48,7 @@ create_ics:
   mpas_init: &mpas_init_config
     boundary_conditions:
       interval_hours: 6
-      length: 6 
+      length: !int "{{ forecast.mpas.length }}" 
       offset: 0
       path: "{{ prepare_grib.ungrib['rundir'] }}"
     execution:

--- a/ush/default_config.yaml
+++ b/ush/default_config.yaml
@@ -48,7 +48,7 @@ create_ics:
   mpas_init: &mpas_init_config
     boundary_conditions:
       interval_hours: 6
-      length: 6
+      length: 6 
       offset: 0
       path: "{{ prepare_grib.ungrib['rundir'] }}"
     execution:


### PR DESCRIPTION
**Synopsis**

<!-- A summary of the change, including relevant motivation, context, useful links, etc. -->

- The FCST_LEN in the cold_start yaml was hardcoded with a value of 12 causing a user supplied forecast greater than 12 to fail the workflow. This implements removing the hard coded value and using a jinja expression to pull the forecast length from `forecast.mpas.length`. 
- In the default config, Ungrib needed to be updated to accommodate a `max_leadtime` greater than 12 as well. I updated to 24 to pass up to a 24 hour forecast.
- Now a user provided yaml config with forecast length specified will pass the workflow.

Tested:
- Successful workflow on Hera.
- Successful workflow on Jet.
- Sucessful workflow for a _regional_ run.

**Type**
- [x] Bug fix (corrects a known issue)

**Impact**
- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [x] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.