### PR TITLE
HFIP 2026 currently running parallel

### DIFF
--- a/parm/wflow/archiving.yaml
+++ b/parm/wflow/archiving.yaml
@@ -68,3 +68,25 @@ workflow:
           metataskdep:
             attrs:
               metatask: post
+
+    task_archive_lbcs:
+      command:
+        cyclestr:
+          value: 'source &MPAS_APP;/load_wflow_modules.sh &PLATFORM; &&
+            cd {{ user.experiment_dir }} &&
+            &MPAS_APP;/scripts/archive_lbcs.sh @Y@m@d@H "&ARCHIVE_DIR;"'
+      account: "{{ platform.account }}"
+      partition: "{{ platform.service_partition }}"
+      join:
+        cyclestr:
+          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+      walltime: "{{ archiving.lbcs.execution.walltime }}"
+      cores: !int "{{ archiving.lbcs.execution.cores }}"
+      dependency:
+        or:
+          taskdep:
+            attrs:
+              task: mpas
+          metataskdep:
+            attrs:
+              metatask: post

--- a/parm/wflow/scrubbing.yaml
+++ b/parm/wflow/scrubbing.yaml
@@ -22,7 +22,22 @@ workflow:
         maxtries: 2
       command:
         cyclestr:
-          value: 'set -xue ; rm -rf "{{ user.experiment_dir }}/@Y@m@d@H/mpas_ics"'
+          value: 'set -xue ; rm -rf "{{ user.experiment_dir }}/@Y@m@d@H/mpas_ics" "{{ user.experiment_dir }}/@Y@m@d@H/ungrib_ics"'
+      account: "{{ platform.account }}"
+      partition: "{{ platform.service_partition }}"
+      join:
+        cyclestr:
+          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+      walltime: "{{ scrubber.execution.walltime }}"
+      cores: !int "{{ scrubber.execution.cores }}"
+      dependency:
+        metataskdep_post:
+          attrs:
+            metatask: post
+    task_scrub_mpas_lbcs:
+      command:
+        cyclestr:
+          value: 'set -xue ; rm -rf "{{ user.experiment_dir }}/@Y@m@d@H/mpas_lbcs" "{{ user.experiment_dir }}/@Y@m@d@H/ungrib_lbcs"'
       account: "{{ platform.account }}"
       partition: "{{ platform.service_partition }}"
       join:

--- a/scripts/archive_lbcs.sh
+++ b/scripts/archive_lbcs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xue
+
+yyyymmddhh=$1
+archive_dir=$2
+
+hsi mkdir -p "$archive_dir" || true
+
+archive="$archive_dir"/${yyyymmddhh}-lbc.tar
+
+listing=$( ls -1 $yyyymmddhh/mpas_lbcs/lbc.*nc )
+
+htar -chpvf "$archive" $listing
+
+echo Normal completion.

--- a/ush/HFIP_2026.yaml
+++ b/ush/HFIP_2026.yaml
@@ -1,0 +1,20 @@
+user:
+  platform: ursa
+  experiment_dir: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/108_gfs_ops
+  hpss_archive_dir: /5year/BMC/fv3lam/role.rtgsd-fv3-dev/HFIP_MPAS_2026/108_gfs_ops
+  input_grib: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/merged-input/102_download_lbcs/out
+  first_cycle: !!timestamp 2026-07-09T12:00:00
+  last_cycle: !!timestamp 2026-12-31T12:00:00
+  cycle_frequency: 24
+
+forecast:
+  mpas:
+    length: 120
+
+workflow:
+  attrs:
+    taskthrottle: 20
+    realtime: true
+
+platform:
+  account: gsd-fv3-dev

--- a/ush/default_config.yaml
+++ b/ush/default_config.yaml
@@ -35,6 +35,7 @@ user:
   workflow_blocks:
     - cold_start.yaml
     - post.yaml
+  hpss_archive_dir: /insert/a/valid/path/here
 data:
   # Known locations to mesh_files are updated from parm/machines/*.yaml files
   mesh_files: /path/to/nonstandard/location
@@ -570,6 +571,10 @@ archiving:
       walltime: 00:29:00
       cores: 1
   init:
+    execution:
+      walltime: 02:59:00
+      cores: 1
+  lbcs:
     execution:
       walltime: 02:59:00
       cores: 1

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -146,19 +146,19 @@ def required_nprocs(experiment_config: YAMLConfig) -> list[int]:
 
 
 def make_cron_script(experiment_config: YAMLConfig, experiment_dir: Path, mpas_app: Path) -> None:
-    filename = experiment_dir / "cron.sh"
+    cron_sh = experiment_dir / "cron.sh"
     machine = experiment_config["user"]["platform"]
-    logging.info("Creating CRON script: %s", filename)
-    with open(filename, 'wt') as fd:
+    logging.info("Creating CRON script: %s", cron_sh)
+    with cron_sh.open('w') as fd:
         fd.write(f"""#!/bin/bash --login
 cd '{mpas_app}'
 source ./load_wflow_modules.sh '{machine}'
 cd '{experiment_dir}'
 rocotorun -w rocoto.xml -d rocoto.db "$@"
 """)
-    sb = os.stat(filename)
+    sb = cron_sh.stat()
     add_user_execute = sb.st_mode | stat.S_IXUSR
-    os.chmod(filename, add_user_execute)
+    cron_sh.chmod(add_user_execute)
 
 def setup_experiment_directory(validated: Config) -> tuple[Path, Path]:
     """

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -7,7 +7,6 @@ Creates the experiment directory and populates it with necessary configuration a
 import argparse
 import inspect
 import logging
-import os
 import stat
 import sys
 from datetime import timedelta
@@ -149,7 +148,7 @@ def make_cron_script(experiment_config: YAMLConfig, experiment_dir: Path, mpas_a
     cron_sh = experiment_dir / "cron.sh"
     machine = experiment_config["user"]["platform"]
     logging.info("Creating CRON script: %s", cron_sh)
-    with cron_sh.open('w') as fd:
+    with cron_sh.open("w") as fd:
         fd.write(f"""#!/bin/bash --login
 cd '{mpas_app}'
 source ./load_wflow_modules.sh '{machine}'

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -150,7 +150,7 @@ def make_cron_script(experiment_config: YAMLConfig, experiment_dir: Path, mpas_a
     machine = experiment_config["user"]["platform"]
     logging.info("Creating CRON script: %s", filename)
     with open(filename, 'wt') as fd:
-        fd.write(f"""#!/bin/sh
+        fd.write(f"""#!/bin/bash --login
 cd '{mpas_app}'
 source ./load_wflow_modules.sh '{machine}'
 cd '{experiment_dir}'

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -7,6 +7,8 @@ Creates the experiment directory and populates it with necessary configuration a
 import argparse
 import inspect
 import logging
+import os
+import stat
 import sys
 from datetime import timedelta
 from pathlib import Path
@@ -79,6 +81,7 @@ def main():
     validated = validate(experiment_config.as_dict())
     experiment_dir, experiment_file = setup_experiment_directory(validated)
     generate_workflow_files(experiment_config, experiment_file, mpas_app, user_config, validated)
+    make_cron_script(experiment_config, experiment_dir, mpas_app)
     stage_grid_files(experiment_config, experiment_dir)
 
 
@@ -141,6 +144,21 @@ def required_nprocs(experiment_config: YAMLConfig) -> list[int]:
             nprocs.append(cores)
     return nprocs
 
+
+def make_cron_script(experiment_config: YAMLConfig, experiment_dir: Path, mpas_app: Path) -> None:
+    filename = experiment_dir / "cron.sh"
+    machine = experiment_config["user"]["platform"]
+    logging.info("Creating CRON script: %s", filename)
+    with open(filename, 'wt') as fd:
+        fd.write(f"""#!/bin/sh
+cd '{mpas_app}'
+source ./load_wflow_modules.sh '{machine}'
+cd '{experiment_dir}'
+rocotorun -w rocoto.xml -d rocoto.db "$@"
+""")
+    sb = os.stat(filename)
+    add_user_execute = sb.st_mode | stat.S_IXUSR
+    os.chmod(filename, add_user_execute)
 
 def setup_experiment_directory(validated: Config) -> tuple[Path, Path]:
     """

--- a/ush/generate_MPAS_HFIP_2026_experiment.sh
+++ b/ush/generate_MPAS_HFIP_2026_experiment.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -xue
+cd ..
+source ./load_wflow_modules.sh ursa
+cd ush
+./experiment_gen.py workflows/hfip_2026.yaml workflows/hfip_resources.yaml workflows/hfip_reservations.yaml HFIP_2026.yaml

--- a/ush/workflows/hfip_2026.yaml
+++ b/ush/workflows/hfip_2026.yaml
@@ -17,24 +17,40 @@ user:
   lbcs:
     data_stores:
       - disk
-  input_grib: /scratch3/BMC/gsd-fv3-dev/role.rtgsd-fv3-dev/MPAS_HFIP_2025/merged-input/out
+  input_grib: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/merged-input/102_download_lbcs/out
+
 data:
   mesh_files: /scratch3/BMC/wrfruc/Clark.Evans/MPAS-Model-v8.3.1/fix
   graphinfo_filename: "{{ user.mesh_label }}.graph.info"
+
 platform:
+  hrrr_fix:  /scratch3/BMC/wrfruc/Clark.Evans/MPAS-Model-v8.3.1/fix
+
   data:
     gfs:
-      path: /scratch3/HFIP/hwrfv3/noscrub/hafs-input/COMGFSv17/gfs.{{ yyyymmdd }}/{{ hh }}/products/atmos/grib2/0p25/
+      path: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/merged-input/102_download_lbcs/out
       file_templates:
-        - gfs.t{{ hh }}z.pres_a.0p25.f{{ "%03d" | format(fcst_hr) }}.grib2
-        - gfs.t{{ hh }}z.pres_b.0p25.f{{ "%03d" | format(fcst_hr) }}.grib2
-  hrrr_fix:  /scratch3/BMC/wrfruc/Clark.Evans/MPAS-Model-v8.3.1/fix
+        - '{{ cycle.strftime("%Y%m%d%H") }}/gfs.t{{ hh }}z.pgrb2.0p25.f{{ "%03d" | format(fcst_hr) }}'
+        - '{{ cycle.strftime("%Y%m%d%H") }}/gfs.t{{ hh }}z.pgrb2b.0p25.f{{ "%03d" | format(fcst_hr) }}'
+
+#  data:
+#    gfs:
+#      path: /public/data/grids/gfs/0p25deg/grib2
+#      file_templates:
+#      - '{{ cycle.strftime("%y%j%H00") }}{{ "%04d" % (lead_time.total_seconds() // 3600) }}'
+
 workflow:
   tasks:
     task_get_ics_data: !remove
     task_ungrib_ics:
       dependency:
         taskdep: !remove
+        datadep:
+          value:
+            cyclestr:
+              value: '{{ user.input_grib }}/@Y@m@d@H/ready'
+    task_get_lbcs_data:
+      dependency:
         datadep:
           value:
             cyclestr:

--- a/ush/workflows/hfip_reservations.yaml
+++ b/ush/workflows/hfip_reservations.yaml
@@ -1,0 +1,54 @@
+platform:
+  account: rtgsd-fv3-dev
+workflow:
+  tasks:
+    task_ungrib_ics:
+      account: rtgsd-fv3-dev
+      native:
+        cyclestr:
+          value: --reservation=gsd_ini_00
+    task_ungrib_lbcs:
+      account: rtgsd-fv3-dev
+      native:
+        cyclestr:
+          value: --reservation=gsd_ini_00
+    task_mpas_ics:
+      account: rtgsd-fv3-dev
+      native:
+        cyclestr:
+          value: --reservation=gsd_ini_00
+    task_mpas_lbcs:
+      account: rtgsd-fv3-dev
+      native:
+        cyclestr:
+          value: --reservation=gsd_ini_00
+    task_mpas:
+      attrs:
+        maxtries: 1
+      account: rtgsd-fv3-dev
+      native:
+        cyclestr:
+          value: --reservation=gsd_fcst_00
+    metatask_post:
+      task_mpassit_#fhr#:
+        account: rtgsd-fv3-dev
+        attrs:
+          maxtries: 9
+        native:
+          cyclestr:
+            value: --reservation=gsd_post_00
+      task_upp_#fhr#:
+        account: rtgsd-fv3-dev
+        native:
+          cyclestr:
+            value: --reservation=gsd_post_00
+      task_combine_grib_#fhr#:
+        account: rtgsd-fv3-dev
+        native:
+          cyclestr:
+            value: --reservation=gsd_post_00
+forecast:
+  mpas:
+    execution:
+      batchargs:
+        walltime: 04:55:00


### PR DESCRIPTION
**Synopsis**

YAML and script changes for the HFIP 2026 experiment. Adds lbc scrubbing, lbc archiving, cron script generation, plus settings specific to the experiment. The `ush/generate_MPAS_HFIP_2026_experiment.sh` is a wrapper around experiment_gen.py that actually generates the experiment.

**Type**

<!-- Select one or more -->

- [ ] Bug fix (corrects a known issue)
- [ ] Code maintenance (refactoring, etc. without behavior change)
- [ ] Documentation
- [x] Enhancement (adds new functionality)
- [ ] Tooling (CI, code-quality, packaging, revision-control, etc.)

**Impact**

<!-- Select one -->

- [x] This is a breaking change (changes existing functionality)
- [ ] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [ ] I have added myself and any co-authors to the PR's _Assignees_ list.
- [ ] I have reviewed the documentation and have made any updates necessitated by this change.