### PR TITLE
Synx with real-time version

### DIFF
--- a/parm/wflow/archiving.yaml
+++ b/parm/wflow/archiving.yaml
@@ -17,7 +17,7 @@ workflow:
         partition: "{{ platform.service_partition }}"
         join:
           cyclestr:
-            value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H_day#day#.log'
+            value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
         walltime: "{{ archiving.mpassit.execution.walltime }}"
         cores: 1
         dependency:
@@ -37,7 +37,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ archiving.upp.execution.walltime }}"
       cores: 1
       dependency:
@@ -57,7 +57,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ archiving.init.execution.walltime }}"
       cores: !int "{{ archiving.init.execution.cores }}"
       dependency:
@@ -70,6 +70,8 @@ workflow:
               metatask: post
 
     task_archive_lbcs:
+      attrs:
+        maxtries: 2
       command:
         cyclestr:
           value: 'source &MPAS_APP;/load_wflow_modules.sh &PLATFORM; &&
@@ -79,7 +81,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ archiving.lbcs.execution.walltime }}"
       cores: !int "{{ archiving.lbcs.execution.cores }}"
       dependency:

--- a/parm/wflow/archiving_tracker.yaml
+++ b/parm/wflow/archiving_tracker.yaml
@@ -12,7 +12,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ archiving.tracker.execution.walltime }}"
       cores: 1
       dependency:

--- a/parm/wflow/cold_start.yaml
+++ b/parm/wflow/cold_start.yaml
@@ -29,7 +29,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ get_ics_data.execution.walltime }}"
       cores: !int "{{ get_ics_data.execution.cores }}"
     task_get_lbcs_data:
@@ -46,7 +46,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ get_lbcs_data.execution.walltime }}"
       cores: !int "{{ get_lbcs_data.execution.cores }}"
     task_ungrib_ics:
@@ -62,7 +62,7 @@ workflow:
       exclusive: "true"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ prepare_grib_ics.ungrib.execution.batchargs.walltime }}"
       nodes: "{{ prepare_grib_ics.ungrib.execution.batchargs.nodes }}:ppn={{ prepare_grib_ics.ungrib.execution.batchargs.tasks_per_node }}"
       dependency:
@@ -82,7 +82,7 @@ workflow:
       exclusive: "true"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ prepare_grib_lbcs.ungrib.execution.batchargs.walltime }}"
       nodes: "{{ prepare_grib_lbcs.ungrib.execution.batchargs.nodes }}:ppn={{ prepare_grib_lbcs.ungrib.execution.batchargs.tasks_per_node }}"
       dependency:
@@ -101,7 +101,7 @@ workflow:
       account: "{{ platform.account }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ create_ics.mpas_init.execution.batchargs.walltime }}"
       cores: !int "{{ create_ics.mpas_init.execution.batchargs.cores }}"
       dependency:
@@ -120,7 +120,7 @@ workflow:
       account: "{{ platform.account }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ create_lbcs.mpas_init.execution.batchargs.walltime }}"
       cores: !int "{{ create_lbcs.mpas_init.execution.batchargs.cores }}"
       dependency:
@@ -143,7 +143,7 @@ workflow:
       account: "{{ platform.account }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ forecast.mpas.execution.batchargs.walltime }}"
       nodes: "{{ forecast.mpas.execution.batchargs.nodes }}:ppn={{ forecast.mpas.execution.batchargs.tasks_per_node }}"
       partition: "{{ forecast.mpas.execution.batchargs.get('partition') }}"

--- a/parm/wflow/graphics.yaml
+++ b/parm/wflow/graphics.yaml
@@ -7,7 +7,7 @@ workflow:
       account: "{{ platform.account }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ graphics.execution.batchargs.walltime }}"
       nodes: "{{ graphics.execution.batchargs.nodes }}:ppn={{ graphics.execution.batchargs.tasks_per_node }}"
       partition: "{{ graphics.execution.batchargs.partition }}"

--- a/parm/wflow/post.yaml
+++ b/parm/wflow/post.yaml
@@ -29,7 +29,8 @@ workflow:
           MESH_LABEL: '{{ user.mesh_label }}'
         join:
           cyclestr:
-            value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+            value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
+        exclusive: "true"
         partition: "{{ post.mpassit.execution.batchargs.partition }}"
         walltime: "{{ post.mpassit.execution.batchargs.walltime }}"
         nodes: "{{ post.mpassit.execution.batchargs.nodes }}:ppn={{ post.mpassit.execution.batchargs.tasks_per_node }}"
@@ -58,7 +59,7 @@ workflow:
         account: "{{ platform.account }}"
         join:
           cyclestr:
-            value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+            value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
         walltime: "{{ post.upp.execution.batchargs.walltime }}"
         nodes: "{{ post.upp.execution.batchargs.nodes }}:ppn={{ post.upp.execution.batchargs.tasks_per_node }}"
         exclusive: "True"
@@ -78,7 +79,7 @@ workflow:
         walltime: 00:02:00
         join:
           cyclestr:
-            value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+            value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
         cores: 1
         envars:
           FHR: '#fhr#'

--- a/parm/wflow/scrubbing.yaml
+++ b/parm/wflow/scrubbing.yaml
@@ -10,7 +10,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ scrubber.execution.walltime }}"
       cores: !int "{{ scrubber.execution.cores }}"
       dependency:
@@ -27,7 +27,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ scrubber.execution.walltime }}"
       cores: !int "{{ scrubber.execution.cores }}"
       dependency:
@@ -42,13 +42,17 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ scrubber.execution.walltime }}"
       cores: !int "{{ scrubber.execution.cores }}"
       dependency:
-        metataskdep_post:
-          attrs:
-            metatask: post
+        and:
+          taskdep_archive:
+            attrs:
+              task: archive_lbcs
+          metataskdep_post:
+            attrs:
+              metatask: post
     task_scrub_mpassit:
       attrs:
         maxtries: 2
@@ -59,7 +63,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ scrubber.execution.walltime }}"
       cores: !int "{{ scrubber.execution.cores }}"
       dependency:
@@ -80,7 +84,7 @@ workflow:
       partition: "{{ platform.service_partition }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ scrubber.execution.walltime }}"
       cores: !int "{{ scrubber.execution.cores }}"
       dependency:

--- a/parm/wflow/start_cycle.yaml
+++ b/parm/wflow/start_cycle.yaml
@@ -1,0 +1,19 @@
+workflow:
+  tasks:
+    task_start_cycle:
+      attrs:
+        maxtries: 1
+      command: /bin/true
+      account: "{{ platform.account }}"
+      join:
+        cyclestr:
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
+      walltime: "{{ start_cycle.execution.batchargs.walltime }}"
+      nodes: "{{ start_cycle.execution.batchargs.nodes }}:ppn={{ start_cycle.execution.batchargs.tasks_per_node }}"
+
+start_cycle:
+  execution:
+    batchargs:
+      walltime: 00:01:00
+      nodes: 1
+      tasks_per_node: 1

--- a/parm/wflow/tracker.yaml
+++ b/parm/wflow/tracker.yaml
@@ -19,7 +19,7 @@ workflow:
                       '
         join:
           cyclestr:
-              value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+              value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
         walltime: "{{ latlon_regrid.execution.batchargs.walltime }}"
         cores: !int "{{ latlon_regrid.execution.batchargs.cores }}"
         partition: "{{ post.upp.execution.batchargs.partition }}"
@@ -40,7 +40,7 @@ workflow:
       account: "{{ platform.account }}"
       join:
         cyclestr:
-          value: '&LOGDIR;/{{ jobname }}_@Y@m@d@H.log'
+          value: '&LOGDIR;/@Y@m@d@H/{{ jobname }}.log'
       walltime: "{{ tracker.gfdltracker.execution.batchargs.walltime }}"
       nodes: "{{ tracker.gfdltracker.execution.batchargs.nodes }}:ppn={{ tracker.gfdltracker.execution.batchargs.tasks_per_node }}"
       exclusive: "{{ tracker.gfdltracker.execution.batchargs.exclusive }}"

--- a/scripts/ungrib.py
+++ b/scripts/ungrib.py
@@ -32,7 +32,6 @@ class UngribHurricane(Ungrib):
 
     @collection
     def gribfiles(self):
-        sys.stderr.write('UNGRIB HURRICANE GRIBFILES\n')
         yield self.taskname("GRIB files")
         gribfiles = Path(self.config["gribfiles"][0])
         chosen_text = (gribfiles / "chosen_storm.txt").read_text()

--- a/scripts/ungrib.py
+++ b/scripts/ungrib.py
@@ -32,6 +32,7 @@ class UngribHurricane(Ungrib):
 
     @collection
     def gribfiles(self):
+        sys.stderr.write('UNGRIB HURRICANE GRIBFILES\n')
         yield self.taskname("GRIB files")
         gribfiles = Path(self.config["gribfiles"][0])
         chosen_text = (gribfiles / "chosen_storm.txt").read_text()

--- a/ush/HFIP_2026.yaml
+++ b/ush/HFIP_2026.yaml
@@ -1,11 +1,27 @@
 user:
   platform: ursa
-  experiment_dir: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/108_gfs_ops
-  hpss_archive_dir: /5year/BMC/fv3lam/role.rtgsd-fv3-dev/HFIP_MPAS_2026/108_gfs_ops
-  input_grib: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/merged-input/102_download_lbcs/out
-  first_cycle: !!timestamp 2026-07-09T12:00:00
-  last_cycle: !!timestamp 2026-12-31T12:00:00
+  experiment_dir: /scratch3/BMC/gsd-fv3-dev/MPAS_HFIP_2026/116_archive_before_scrubbing
+  hpss_archive_dir: /5year/BMC/fv3lam/role.rtgsd-fv3-dev/HFIP_MPAS_2026/116_archive_before_scrubbing
+  input_grib: /scratch5/BMC/gsd-fv3-dev/MPAS_HFIP_2026/merged-input/104_sam_gfs_v17/out
+  first_cycle: !!timestamp 2026-07-28T06:00:00
+  last_cycle: !!timestamp 2026-12-31T06:00:00
   cycle_frequency: 24
+  scripts:
+    start_cycle.sh:
+      name: start_cycle.sh
+      executable: true
+      content: |+
+        #!/bin/bash --login
+        
+        hh=$1
+        shift 1
+        
+        cd {{user.mpas_app}}
+        source ./load_wflow_modules.sh {{user.platform}}
+        cd {{user.experiment_dir}}
+        sleep $(( 10  + RANDOM/1100 ))
+        yes | rocotoboot -w rocoto.xml -d rocoto.db -c $( date +%Y%m%d )${hh}00 -t start_cycle "$@"
+        
 
 forecast:
   mpas:

--- a/ush/default_config.yaml
+++ b/ush/default_config.yaml
@@ -36,6 +36,18 @@ user:
     - cold_start.yaml
     - post.yaml
   hpss_archive_dir: /insert/a/valid/path/here
+  scripts:
+    cron.sh:
+      name: cron.sh
+      executable: true
+      content: |+
+        #!/bin/bash --login
+        cd {{user.mpas_app}}
+        source ./load_wflow_modules.sh {{user.platform}}
+        cd {{user.experiment_dir}}
+        rocotorun -w rocoto.xml -d rocoto.db "$@"
+        
+
 data:
   # Known locations to mesh_files are updated from parm/machines/*.yaml files
   mesh_files: /path/to/nonstandard/location
@@ -576,7 +588,7 @@ archiving:
       cores: 1
   lbcs:
     execution:
-      walltime: 02:59:00
+      walltime: 04:59:00
       cores: 1
 
 scrubber:

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -80,7 +80,7 @@ def main():
     validated = validate(experiment_config.as_dict())
     experiment_dir, experiment_file = setup_experiment_directory(validated)
     generate_workflow_files(experiment_config, experiment_file, mpas_app, user_config, validated)
-    make_cron_script(experiment_config, experiment_dir, mpas_app)
+    make_user_scripts(experiment_file, experiment_dir, mpas_app)
     stage_grid_files(experiment_config, experiment_dir)
 
 
@@ -144,20 +144,36 @@ def required_nprocs(experiment_config: YAMLConfig) -> list[int]:
     return nprocs
 
 
-def make_cron_script(experiment_config: YAMLConfig, experiment_dir: Path, mpas_app: Path) -> None:
-    cron_sh = experiment_dir / "cron.sh"
-    machine = experiment_config["user"]["platform"]
-    logging.info("Creating CRON script: %s", cron_sh)
-    with cron_sh.open("w") as fd:
-        fd.write(f"""#!/bin/bash --login
-cd '{mpas_app}'
-source ./load_wflow_modules.sh '{machine}'
-cd '{experiment_dir}'
-rocotorun -w rocoto.xml -d rocoto.db "$@"
-""")
-    sb = cron_sh.stat()
-    add_user_execute = sb.st_mode | stat.S_IXUSR
-    cron_sh.chmod(add_user_execute)
+def make_user_scripts(experiment_file: Path, experiment_dir: Path, mpas_app: Path) -> None:
+    config = get_yaml_config(experiment_file)
+    if "scripts" not in config["user"]:
+        logging.warning("No user.scripts found in yaml")
+        return
+    user_scripts = config["user"]["scripts"]
+    if not user_scripts:
+        logging.warning("user.scripts is empty")
+    for key, value in user_scripts.items():
+        generate_file_from_yaml(experiment_dir, key, value)
+
+
+def generate_file_from_yaml(experiment_dir: Path, key: str, script: Config):
+    path = experiment_dir / script['name']
+    parent = path.parent
+    contents = script['content']
+    executable = 'executable' in script and script['executable']
+
+    if not parent.exists():
+        logging.info("Creating user-defined directory: %s", parent)
+        parent.mkdir(parents=True, exists_ok=True)
+
+    logging.info("Creating user-defined file: %s", path)
+    with path.open("w") as fd:
+        fd.write(contents)
+
+    if executable:
+        sb = path.stat()
+        add_user_execute = sb.st_mode | stat.S_IXUSR
+        path.chmod(add_user_execute)
 
 
 def setup_experiment_directory(validated: Config) -> tuple[Path, Path]:

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -152,7 +152,7 @@ def make_user_scripts(experiment_file: Path, experiment_dir: Path) -> None:
     user_scripts = config["user"]["scripts"]
     if not user_scripts:
         logging.warning("user.scripts is empty")
-    for key, value in user_scripts.items():
+    for value in user_scripts.values():
         generate_file_from_yaml(experiment_dir, value)
 
 

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -80,7 +80,7 @@ def main():
     validated = validate(experiment_config.as_dict())
     experiment_dir, experiment_file = setup_experiment_directory(validated)
     generate_workflow_files(experiment_config, experiment_file, mpas_app, user_config, validated)
-    make_user_scripts(experiment_file, experiment_dir)
+    make_user_scripts(experiment_file, experiment_dir, mpas_app)
     stage_grid_files(experiment_config, experiment_dir)
 
 
@@ -144,7 +144,7 @@ def required_nprocs(experiment_config: YAMLConfig) -> list[int]:
     return nprocs
 
 
-def make_user_scripts(experiment_file: Path, experiment_dir: Path) -> None:
+def make_user_scripts(experiment_file: Path, experiment_dir: Path, mpas_app: Path) -> None:
     config = get_yaml_config(experiment_file)
     if "scripts" not in config["user"]:
         logging.warning("No user.scripts found in yaml")
@@ -152,15 +152,15 @@ def make_user_scripts(experiment_file: Path, experiment_dir: Path) -> None:
     user_scripts = config["user"]["scripts"]
     if not user_scripts:
         logging.warning("user.scripts is empty")
-    for value in user_scripts.values():
-        generate_file_from_yaml(experiment_dir, value)
+    for key, value in user_scripts.items():
+        generate_file_from_yaml(experiment_dir, key, value)
 
 
-def generate_file_from_yaml(experiment_dir: Path, script: Config):
-    path = experiment_dir / script["name"]
+def generate_file_from_yaml(experiment_dir: Path, key: str, script: Config):
+    path = experiment_dir / script['name']
     parent = path.parent
-    contents = script["content"]
-    executable = "executable" in script and script["executable"]
+    contents = script['content']
+    executable = 'executable' in script and script['executable']
 
     if not parent.exists():
         logging.info("Creating user-defined directory: %s", parent)

--- a/ush/experiment_gen.py
+++ b/ush/experiment_gen.py
@@ -80,7 +80,7 @@ def main():
     validated = validate(experiment_config.as_dict())
     experiment_dir, experiment_file = setup_experiment_directory(validated)
     generate_workflow_files(experiment_config, experiment_file, mpas_app, user_config, validated)
-    make_user_scripts(experiment_file, experiment_dir, mpas_app)
+    make_user_scripts(experiment_file, experiment_dir)
     stage_grid_files(experiment_config, experiment_dir)
 
 
@@ -144,7 +144,7 @@ def required_nprocs(experiment_config: YAMLConfig) -> list[int]:
     return nprocs
 
 
-def make_user_scripts(experiment_file: Path, experiment_dir: Path, mpas_app: Path) -> None:
+def make_user_scripts(experiment_file: Path, experiment_dir: Path) -> None:
     config = get_yaml_config(experiment_file)
     if "scripts" not in config["user"]:
         logging.warning("No user.scripts found in yaml")
@@ -153,14 +153,14 @@ def make_user_scripts(experiment_file: Path, experiment_dir: Path, mpas_app: Pat
     if not user_scripts:
         logging.warning("user.scripts is empty")
     for key, value in user_scripts.items():
-        generate_file_from_yaml(experiment_dir, key, value)
+        generate_file_from_yaml(experiment_dir, value)
 
 
-def generate_file_from_yaml(experiment_dir: Path, key: str, script: Config):
-    path = experiment_dir / script['name']
+def generate_file_from_yaml(experiment_dir: Path, script: Config):
+    path = experiment_dir / script["name"]
     parent = path.parent
-    contents = script['content']
-    executable = 'executable' in script and script['executable']
+    contents = script["content"]
+    executable = "executable" in script and script["executable"]
 
     if not parent.exists():
         logging.info("Creating user-defined directory: %s", parent)

--- a/ush/workflows/hfip_2026.yaml
+++ b/ush/workflows/hfip_2026.yaml
@@ -8,6 +8,7 @@ user:
     - archiving.yaml
     - tracker.yaml
     - archiving_tracker.yaml
+    - start_cycle.yaml
   first_cycle: !!timestamp 2025-10-14T00:00:00
   last_cycle: !!timestamp 2025-10-14T00:00:00
   hpss_archive_dir: /path/to/hpss/dir
@@ -17,7 +18,7 @@ user:
   lbcs:
     data_stores:
       - disk
-  input_grib: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/merged-input/102_download_lbcs/out
+  input_grib: /scratch5/BMC/gsd-fv3-dev/MPAS_HFIP_2026/merged-input/104_sam_gfs_v17/out
 
 data:
   mesh_files: /scratch3/BMC/wrfruc/Clark.Evans/MPAS-Model-v8.3.1/fix
@@ -28,16 +29,10 @@ platform:
 
   data:
     gfs:
-      path: /scratch5/purged/role.rtgsd-fv3-dev/MPAS_HFIP_2026/merged-input/102_download_lbcs/out
+      path: '{{user.input_grib}}'
       file_templates:
-        - '{{ cycle.strftime("%Y%m%d%H") }}/gfs.t{{ hh }}z.pgrb2.0p25.f{{ "%03d" | format(fcst_hr) }}'
-        - '{{ cycle.strftime("%Y%m%d%H") }}/gfs.t{{ hh }}z.pgrb2b.0p25.f{{ "%03d" | format(fcst_hr) }}'
-
-#  data:
-#    gfs:
-#      path: /public/data/grids/gfs/0p25deg/grib2
-#      file_templates:
-#      - '{{ cycle.strftime("%y%j%H00") }}{{ "%04d" % (lead_time.total_seconds() // 3600) }}'
+        - '{{ cycle.strftime("%Y%m%d%H") }}/gfs.t{{ hh }}z.pres_a.0p25.f{{ "%03d" | format(fcst_hr) }}.grib2'
+        - '{{ cycle.strftime("%Y%m%d%H") }}/gfs.t{{ hh }}z.pres_b.0p25.f{{ "%03d" | format(fcst_hr) }}.grib2'
 
 workflow:
   tasks:
@@ -50,6 +45,7 @@ workflow:
             cyclestr:
               value: '{{ user.input_grib }}/@Y@m@d@H/ready'
     task_get_lbcs_data:
+      walltime: 00:20:00
       dependency:
         datadep:
           value:
@@ -142,8 +138,8 @@ forecast:
           config_rayleigh_damp_u: true
           config_rayleigh_damp_u_timescale_days: 2.5
         io:
-          config_pio_num_iotasks: 45
-          config_pio_stride: 180
+          config_pio_num_iotasks: 810
+          config_pio_stride: 10
         limited_area:
           config_apply_lbcs: true
         physics:
@@ -154,6 +150,7 @@ forecast:
           config_gvf_update: true
           config_lsm_scheme: sf_noah
           num_soil_layers: 4
+          config_mynn_sfcflux_water: 2
         physics_lsm_noahmp: !remove
         physics_mp_tempo:
           config_tempo_aerosolaware: true

--- a/ush/workflows/hfip_reservations.yaml
+++ b/ush/workflows/hfip_reservations.yaml
@@ -19,6 +19,7 @@ workflow:
           value: --reservation=gsd_ini_00
     task_mpas_lbcs:
       account: rtgsd-fv3-dev
+      walltime: 00:20:00
       native:
         cyclestr:
           value: --reservation=gsd_ini_00


### PR DESCRIPTION
**Synopsis**

Main highlights:

1. Logs are in per-cycle subdirectories. Tens of thousands of logs in one directory is problematic.
2. Archive LBCs before scrubbing them.
4. The cron.sh is generated from a YAML string instead of hard-coded into a Python function.
5. A dummy start_cycle job and start_cycle.sh script (alongside cron.sh) to allow CRON to force Rocoto to start a cycle. This is a workaround for a bug wherein Rocoto won't reliably start a cycle when job dependencies are met. It uses the same functionality as generating cron.sh.
6. Various resource changes and new disk areas to get things to run reliably.

**Type**

<!-- Select one or more -->

- [x] Bug fix (corrects a known issue)
- [x] Enhancement (adds new functionality)

**Impact**

<!-- Select one -->

- [x] This is a non-breaking change (existing functionality continues to work as expected)

**Checklist**

<!-- Affirm -->

- [ ] I have added myself and any co-authors to the PR's _Assignees_ list.
- [x] I have reviewed the documentation and have made any updates necessitated by this change.